### PR TITLE
Insert word-wrap into article definition

### DIFF
--- a/_includes/css/style.css
+++ b/_includes/css/style.css
@@ -197,6 +197,7 @@ article {
   margin: 0 10px;
   box-shadow: 0 3px 10px rgba(0,0,0,.1);
   font-size: 16px;
+  word-wrap: break-word;
 }
 article h2 {
     color: #000;


### PR DESCRIPTION
in order to avoid lines running over their '<div>' containers.

Simple example: http://www.w3schools.com/cssref/tryit.asp?filename=trycss3_word-wrap
